### PR TITLE
added ability to specify volume propogation type for power users

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,11 +7,19 @@ module.exports = {
             var parts = volume.split(":");
 
             volume = {
-                container: parts[1]
+              container: 1 === parts.length ? parts[0] : parts[1]
             }
 
-            if(!_.isEmpty(parts[0]))
-                volume.host = parts[0];
+            if (1 < parts.length) {
+                if(!_.isEmpty(parts[0])) {
+                    volume.host = parts[0];
+                }
+
+                // ex: /host/path:/container/path:{propogationType}
+                if (3 === parts.length) {
+                  volume.propogation = parts[2];
+                }
+            }
 
             return volume;
         });


### PR DESCRIPTION
Examples:
`--volume /container/path` -> `{ container: '/container/path' }`
`--volume :/container/path` -> `{ container: '/container/path' }`
`--volume /host/path:/container/path` -> `{ container: '/container/path', host: '/host/path' }`
`--volume /host/path:/container/path:shared` -> `{ container: '/container/path', host: '/host/path', propogation: 'shared' }`


@normanjoyner 