### PR TITLE
fix(deps): update to cli-table3

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const chalk = require('chalk');
-const Table = require('cli-table2');
+const Table = require('cli-table3');
 
 module.exports.createTable = function(headers, data, config) {
     headers = headers.map(header => chalk.bold.red(header));

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@containership/containership.schema-converter": "^0.1.0",
     "async": "^2.4.1",
     "chalk": "^2.0.1",
-    "cli-table2": "^0.2.0",
+    "cli-table3": "^0.5.0",
     "depcheck": "^0.6.7",
     "flat": "^4.0.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This PR updates the cli-table2 dependency to cli-table3, which fixes one of the npm audit warnings :)

cli-table2 (like cli-table itself) is no longer maintained. In jamestalmage/cli-table2#43 a couple of people have offered to take over maintenance but the current maintainer did not respond so as a result the project was forked to cli-table/cli-table3.